### PR TITLE
Disable vertical gallery layout for dancewear products

### DIFF
--- a/customization/frontend-settings.php
+++ b/customization/frontend-settings.php
@@ -8,6 +8,9 @@ add_filter( 'blazecommerce/settings/product', function ($settings) {
 	// We make the product gallery to grid layout
 	$settings['productGallery']['isGrid'] = true;
 
+	// Disable vertical layout for dancewear products - use default horizontal layout
+	$settings['productGallery']['isVertical'] = false;
+
 	return $settings;
 }, 10, 1 );
 


### PR DESCRIPTION
## Problem

The dancewear products were displaying with a vertical thumbnail layout (thumbnails on the left side) which doesn't suit the product presentation needs for dancewear items. The vertical layout was being forced by default in the frontend.

## Solution

Added configuration to disable the vertical gallery layout specifically for the dancewear site:

```php
add_filter( 'blazecommerce/settings/product', function ($settings) {

	// We make the product gallery to grid layout
	$settings['productGallery']['isGrid'] = true;
	
	// Disable vertical layout for dancewear products - use default horizontal layout
	$settings['productGallery']['isVertical'] = false;

	return $settings;
}, 10, 1 );
```

## Changes

- **Added `isVertical: false`** - Disables the vertical thumbnail layout
- **Keeps `isGrid: true`** - Maintains the grid layout for better product display
- **Uses default horizontal layout** - Thumbnails appear below the main image (traditional layout)

## Files Changed

- `customization/frontend-settings.php` - Added vertical layout configuration

## Impact

✅ **Dancewear products now use horizontal thumbnail layout**
✅ **Grid layout remains enabled for optimal product presentation**
✅ **Prevents unwanted layout changes that don't suit dancewear products**
✅ **Maintains existing functionality while improving UX**

## Dependencies

This change works in conjunction with the frontend fix in [blazecommerce-frontend PR #88](https://github.com/blaze-commerce/blazecommerce-frontend/pull/88) which makes the `isVertical` setting configurable.

## Testing

After both PRs are merged:
- Dancewear product pages will show horizontal thumbnails below main image
- Grid layout will remain active for better product image display
- Variant selection will work correctly without affecting all gallery images

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author