### PR TITLE
fix(performance): disable Action Scheduler on staging domains

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,10 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive documentation structure in `/docs` directory
 - Mandatory documentation requirements for all code changes
 - Documentation-first development workflow
+- Action Scheduler conditional disabling for staging environments
 
 ### Changed
 - Updated `.augment-guidelines` to mandate comprehensive .md documentation
 - Enhanced commit guidelines to require documentation updates
+
+### Performance
+- Disabled Action Scheduler background processing on `.blz.onl` staging domains to prevent unnecessary resource usage
 
 ## [1.0.1] - 2024-12-12
 

--- a/docs/FUNCTIONS.md
+++ b/docs/FUNCTIONS.md
@@ -254,6 +254,41 @@ if (blazecommerce_child_is_woocommerce_page()) {
 
 **Since**: 1.0.0
 
+### `blaze_disable_action_scheduler_for_staging()`
+
+**Description**: Conditionally disables Action Scheduler background processing on staging domains containing `.blz.onl` to prevent unnecessary resource usage and potential conflicts.
+
+**Location**: `functions.php`
+
+**Usage**:
+```php
+function blaze_disable_action_scheduler_for_staging() {
+    // Check if the current domain contains .blz.onl
+    $current_domain = $_SERVER['HTTP_HOST'] ?? '';
+
+    if (strpos($current_domain, '.blz.onl') !== false) {
+        // Disable Action Scheduler queue runner interval
+        add_filter('action_scheduler_queue_runner_interval', '__return_false');
+
+        // Disable Action Scheduler default runner
+        add_filter('action_scheduler_disable_default_runner', '__return_true');
+    }
+}
+add_action('init', 'blaze_disable_action_scheduler_for_staging');
+```
+
+**Parameters**: None
+
+**Return**: void
+
+**Since**: 1.0.1
+
+**Filters Applied**:
+- `action_scheduler_queue_runner_interval`: Set to `false` to disable queue processing intervals
+- `action_scheduler_disable_default_runner`: Set to `true` to disable the default background runner
+
+**Domain Detection**: Only activates when `$_SERVER['HTTP_HOST']` contains `.blz.onl`
+
 ---
 
 ## Hook Reference

--- a/functions.php
+++ b/functions.php
@@ -446,3 +446,18 @@ function blaze_debug_patterns() {
         exit;
     }
 }
+
+// Disable Action Scheduler for .blz.onl domains
+add_action('init', 'blaze_disable_action_scheduler_for_staging');
+function blaze_disable_action_scheduler_for_staging() {
+    // Check if the current domain contains .blz.onl
+    $current_domain = $_SERVER['HTTP_HOST'] ?? '';
+
+    if (strpos($current_domain, '.blz.onl') !== false) {
+        // Disable Action Scheduler queue runner interval
+        add_filter('action_scheduler_queue_runner_interval', '__return_false');
+
+        // Disable Action Scheduler default runner
+        add_filter('action_scheduler_disable_default_runner', '__return_true');
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements conditional disabling of Action Scheduler background processing on staging environments to prevent unnecessary resource usage and potential conflicts.

## Changes Made

### Core Functionality
- Added `blaze_disable_action_scheduler_for_staging()` function that detects `.blz.onl` domains
- Conditionally applies two Action Scheduler filters:
  - `action_scheduler_queue_runner_interval` → `__return_false`
  - `action_scheduler_disable_default_runner` → `__return_true`
- Hooked to `init` action for proper timing of domain detection

### Documentation Updates
- Updated `docs/FUNCTIONS.md` with comprehensive documentation for the new function
- Added detailed usage examples, parameters, and filter descriptions
- Updated `docs/CHANGELOG.md` with performance optimization entry

## Technical Details

**Domain Detection**: Uses `$_SERVER['HTTP_HOST']` with null coalescing operator for safe domain checking

**Staging Environment Identification**: Targets domains containing `.blz.onl` substring

**Performance Impact**: 
- ✅ Eliminates unnecessary background processing on staging
- ✅ Reduces server resource usage
- ✅ Prevents potential staging environment conflicts
- ✅ No impact on production domains

## Testing

- [x] Function only activates on `.blz.onl` domains
- [x] Both Action Scheduler filters are properly applied
- [x] No impact on production environments
- [x] Documentation follows project standards

## Backward Compatibility

✅ **Fully backward compatible** - This change only affects staging domains and has no impact on existing production functionality.

## Related Issues

Addresses performance optimization requirements for staging environments in the BlazeCommerce ecosystem.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author